### PR TITLE
Fixed social media icons in Safari

### DIFF
--- a/components/base_page.js
+++ b/components/base_page.js
@@ -12,6 +12,7 @@ import { SITE_TITLE, PAGE_TITLES } from '../constants/seo.js';
 
 import css from '../styles/common.module.scss';
 import utilsCss from '../styles/utils.module.scss';
+import '@fortawesome/fontawesome-svg-core/styles.css';
 
 export default function Page({ children }) {
     const router = useRouter();


### PR DESCRIPTION
Fixed the social media icons in Safari. FontAwesome updated their documentation to include better compatibility with [NextJS](https://fontawesome.com/v5.15/how-to-use/on-the-web/using-with/react#nextjs).

![Screen Shot 2021-09-27 at 3 54 19 PM](https://user-images.githubusercontent.com/57340860/134996065-7a33ed3e-a184-4c8d-b0f0-8fc2e4545a6b.png)